### PR TITLE
fix(issue):修复遗留问题lowerLimit和upperLimit只对值生效未对滑动做限制

### DIFF
--- a/package/harmony/slider/src/main/ets/Slider.ets
+++ b/package/harmony/slider/src/main/ets/Slider.ets
@@ -37,6 +37,9 @@ const TAG: string = "[RNOH] RNCSlider"
 
 export const SLIDER_TYPE: string = "RNCSlider"
 
+const DEFAULT_LIMIT_VALUE = -9007199254740991;
+const DEFAULT_MAX_VALUE = 9007199254740991;
+
 export interface SliderProps extends ViewBaseProps {
   thumbImage?: string
   maximumTrackTintColor?: ColorSegments
@@ -170,6 +173,10 @@ export struct RNCSlider {
         .showSteps(false)
         .blockStyle(this.descriptorWrapper?.BlockStyle)
         .onChange((value: number, mode: SliderChangeMode) => this.onSliderChange(value, mode))
+        .slideRange({
+          from: this.lowerLimit === DEFAULT_LIMIT_VALUE ? this.descriptorWrapper?.minimumValue : this.lowerLimit,
+          to: this.upperLimit === DEFAULT_MAX_VALUE ? this.descriptorWrapper?.maximumValue : this.upperLimit
+        })
     }
   }
 }


### PR DESCRIPTION
Summary:
fix(issue):修复遗留问题lowerLimit和upperLimit只对值生效未对滑动做限制
Close: https://github.com/react-native-oh-library/react-native-slider/issues/2

Test Plan:
在silder里面配置lowerLimit,upperLimit属性并测试
已验证ok

Checklist
- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)